### PR TITLE
Add normalized search

### DIFF
--- a/bin/dasht-docsets
+++ b/bin/dasht-docsets
@@ -46,9 +46,27 @@
 # Written in 2016 by Suraj N. Kurapati <https://github.com/sunaku/dasht>
 # Distributed under the terms of the ISC license (see the LICENSE file).
 
+normalize() {
+  sed 's/[-_+\.]//g' <<<"$1"
+}
+searchterms="$(normalize $(IFS='|'; echo "$*"))"
+
+searchFn() {
+  id="$1"
+  normalizedid=$(normalize "$id")
+  if grep -i "$searchterms" <<<"$normalizedid" >/dev/null
+  then
+    echo "$id"
+  fi
+}
+
+export -f searchFn
+export -f normalize
+export searchterms="$searchterms"
+
 : ${DASHT_DOCSETS_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}/dasht/docsets}
 
 ls "$DASHT_DOCSETS_DIR" |
 sed -n 's/\.docset$//p' |
 sort -u |
-grep -E -i "$(IFS='|'; echo "$*")"
+xargs -I{} bash -c 'searchFn {}'

--- a/bin/dasht-query-line
+++ b/bin/dasht-query-line
@@ -94,6 +94,12 @@ test $# -gt 0 && shift # shift off PATTERN so argv contains solely DOCSETs
 status=44 # (default) exit with a nonzero status when no results are found
 trap 'status=0' USR1 # override default exit status when results are found
 
+if ! dasht-docsets "$@"
+then
+  echo "No docset matching your query found" 1>&2
+  exit 44
+fi
+
 dasht-docsets "$@" | while read -r docset; do
   database="$DASHT_DOCSETS_DIR/$docset".docset/Contents/Resources/docSet.dsidx
   file_url="file://$(dirname "$database")/Documents/"


### PR DESCRIPTION
This makes it possible to find results in lodash docsets by running:

dasht get lodash # this was returning no results before

or

dasht get lo-dash

when the docset name is "Lo-Dash"