### PR TITLE
Fix remove of stale files containing spaces

### DIFF
--- a/bin/dasht-docsets-extract
+++ b/bin/dasht-docsets-extract
@@ -72,12 +72,10 @@ for tgz; do
   # remove any stale files that were left behind by the previous extraction
   { find "$want" -print
     tar -t -f "$tgz" -z | sed -e "s|^[^/]*|$want|" -e 's|/$||'
-  } | sort -r | uniq -c | sed -n 's/^ *1 //p' | xargs sh -e -u -c '
-    for arg; do
+  } | sort -r | uniq -c | sed -n 's/^ *1 //p' | while read -r arg; do
       if test -d "$arg"
       then rmdir "$arg"
       else rm -v "$arg"
       fi
-    done
-  ' :
+  done
 done


### PR DESCRIPTION
replace xargs with while read, avoid globbing

the same could be achived by using xargs with `-0`
(GNU/BSD) if newline is replaced with `\0`

    tr '\n' '\0' | xargs -0 sh -e -u -c '

but I think this solution is cleaner

fixes: https://github.com/sunaku/dasht/issues/35