### PR TITLE
update AUR maintainer. remove orphaned package

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,8 @@ Development:
 
 In Arch Linux:
 
-* Install [dasht](https://aur.archlinux.org/packages/dasht/) or
-  [dasht-git](https://aur.archlinux.org/packages/dasht-git/) from the AUR,
-  maintained by [Christian Höppner](https://github.com/mkaito).
+* Install [dasht](https://aur.archlinux.org/packages/dasht/)
+  maintained by [Shane Forster](https://github.com/Shane4STER).
 
 In macOS using [Homebrew](https://brew.sh):
 


### PR DESCRIPTION
Christian Höppner (@mkaito) has orphaned the package on AUR, I have adopted it, updated documentation to reflect this, and the removal of the very outdated and orphaned `dasht-git` package