### PR TITLE
update AUR maintainer. remove orphaned package

### DIFF
--- a/man/man0/README
+++ b/man/man0/README
@@ -75,9 +75,8 @@ gem install binman md2man
 In Arch Linux:
 .RS
 .IP \(bu 2
-Install dasht \[la]https://aur.archlinux.org/packages/dasht/\[ra] or
-dasht\-git \[la]https://aur.archlinux.org/packages/dasht-git/\[ra] from the AUR,
-maintained by Christian Höppner \[la]https://github.com/mkaito\[ra]\&.
+Install dasht \[la]https://aur.archlinux.org/packages/dasht/\[ra]
+maintained by Shane Forster \[la]https://github.com/Shane4STER\[ra]\&.
 .RE
 .PP
 In macOS using Homebrew \[la]https://brew.sh\[ra]:

--- a/man/man0/README.html
+++ b/man/man0/README.html
@@ -43,9 +43,8 @@ and &quot;<a href="https://vimeo.com/159462774">dasht in a browser</a>&quot; scr
 </ul>
 <h2 id="installation">Installation<a name="installation" href="#installation" class="md2man-permalink" title="permalink"></a></h2><p>In Arch Linux:</p>
 <ul>
-<li>Install <a href="https://aur.archlinux.org/packages/dasht/">dasht</a> or
-<a href="https://aur.archlinux.org/packages/dasht-git/">dasht-git</a> from the AUR,
-maintained by <a href="https://github.com/mkaito">Christian Höppner</a>.</li>
+<li>Install <a href="https://aur.archlinux.org/packages/dasht/">dasht</a>
+maintained by <a href="https://github.com/Shane4STER">Shane Forter</a>.</li>
 </ul>
 <p>In macOS using <a href="https://brew.sh">Homebrew</a>:</p><div class="highlight"><pre class="highlight plaintext"><code>brew install dasht
 </code></pre></div><p>On any system:</p>

--- a/man/man0/README.md
+++ b/man/man0/README.md
@@ -74,9 +74,8 @@ Development:
 
 In Arch Linux:
 
-* Install [dasht](https://aur.archlinux.org/packages/dasht/) or
-  [dasht-git](https://aur.archlinux.org/packages/dasht-git/) from the AUR,
-  maintained by [Christian Höppner](https://github.com/mkaito).
+* Install [dasht](https://aur.archlinux.org/packages/dasht/)
+  maintained by [Shane Forster](https://github.com/Shane4STER).
 
 In macOS using [Homebrew](https://brew.sh):
 


### PR DESCRIPTION
Christian Höppner (@mkaito) has orphaned the package on AUR, I have adopted it, updated documentation to reflect this, and the removal of the very outdated and orphaned `dasht-git` package