### PR TITLE
add support for using existing Dash.app docsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,7 @@ Optional:
 
 * [gawk] for dasht-server(1) search engine
 
-[Dash.app]: https://kapeli.com/dash
-
-* [Dash.app] to let the Dash MacOS app manage your docsets
+* [Dash] to let the Dash MacOS app manage your docsets
 
 Development:
 
@@ -102,8 +100,8 @@ Manually, on any system:
 Set `DASHT_USE_DASH_APP=true` to use the docsets stored by Dash.app on your
 machine. This makes `dasht` act like a read-only client for your Dash.app
 docset library-- all docset management commands (`install`, `update`, `remove`)
-are disabled. This also provides access to an expanded library of docsets, as
-at present `dasht` itself can only download and/or build a subset of the
+are disabled. This also provides access to an expanded library of docsets,
+because currently `dasht` can only download and/or build a subset of the
 docsets available through Dash.app.
 
 ### Vim integration

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ which aptly characterizes the terminal environment where everything is text.
 
 * Keep [Dash] docsets anywhere you like.
 
+* Access existing docset library managed by Dash.app (MacOS only).
+
 ### Preview
 
 Watch the "[dasht in a terminal](https://vimeo.com/159462598)"
@@ -61,6 +63,10 @@ Optional:
 
 * [gawk] for dasht-server(1) search engine
 
+[Dash.app]: https://kapeli.com/dash
+
+* [Dash.app] to let the Dash MacOS app manage your docsets
+
 Development:
 
 [binman]: https://sunaku.github.io/binman/
@@ -90,6 +96,15 @@ Manually, on any system:
 3.  Add the `man/` folder to your `MANPATH` environment variable:
 
         export MANPATH=location_where_you_cloned_or_downloaded_dasht/man:$MANPATH
+
+### Dash.app integration
+
+Set `DASHT_USE_DASH_APP=true` to use the docsets stored by Dash.app on your
+machine. This makes `dasht` act like a read-only client for your Dash.app
+docset library-- all docset management commands (`install`, `update`, `remove`)
+are disabled. This also provides access to an expanded library of docsets, as
+at present `dasht` itself can only download and/or build a subset of the
+docsets available through Dash.app.
 
 ### Vim integration
 
@@ -141,6 +156,11 @@ You may optionally configure the `DASHT_CACHE_DIR` environment variable,
 which defines the filesystem location where download links are cached.
 If undefined, its value is assumed to be `$XDG_CACHE_HOME/dasht/`
 or, if `XDG_CACHE_HOME` is also undefined, `$HOME/.cache/dasht/`.
+
+Set `DASHT_USE_DASH_APP=true` to enable Dash.app integration (MacOS only). See
+[Dash.app integration](#dashapp-integration) for details. Note that this will
+also change the default setting of `DASHT_DOCSETS_DIR` to `~/Libary/Application
+Support/Dash` (where Dash.app docsets are stored by default).
 
 ## Development
 

--- a/bin/dasht
+++ b/bin/dasht
@@ -48,6 +48,11 @@
 #   If undefined, its value is assumed to be `$XDG_DATA_HOME/dasht/docsets/`
 #   or, if `XDG_DATA_HOME` is undefined, `$HOME/.local/share/dasht/docsets/`.
 #
+# `DASHT_USE_DASH_APP`
+#   Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+#   docset management commands (install, remove, update). Also changes the
+#   default `DASHT_DOCSETS_DIR` to "~/Library/Application Support/Dash".
+#
 # ## EXIT STATUS
 #
 # 44

--- a/bin/dasht
+++ b/bin/dasht
@@ -87,12 +87,7 @@ fi
 # Ensure any docsets we are accessing from the Dash.app library have had their
 # documents extracted. Dash.app leaves the documents in the tarball by default.
 if $DASHT_USE_DASH_APP; then
-  dasht-docsets "$@" | while read docset; do
-    root=("$DASHT_DOCSETS_DIR/"*/*"/${docset}.docset")
-    if ! test -d "${root}/Contents/Resources/Documents"; then
-      dasht-docsets-extract "$root/Contents/Resources/tarix.tgz"
-    fi
-  done
+  dasht-docsets-inherit "$@"
 fi
 
 count=$(dasht-docsets "$@" | wc -l)

--- a/bin/dasht
+++ b/bin/dasht
@@ -74,7 +74,7 @@
 
 : ${DASHT_USE_DASH_APP:=false}
 if $DASHT_USE_DASH_APP; then
-  : ${DASHT_DOCSETS_DIR:="/Users/smackesey/Library/Application Support/Dash"}
+  : ${DASHT_DOCSETS_DIR:="$HOME/Library/Application Support/Dash"}
 else
   : ${DASHT_DOCSETS_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}/dasht/docsets}
 fi
@@ -103,7 +103,6 @@ if test $count -eq 0; then
 fi
 
 trap 'exit 44' USR1 # exit with a nonzero status when no results are found
-
 if ! dasht-query-html "$pattern" "$@"; then
   # notify user when no results are found so they can refine their search
   echo "dasht: '$pattern' not found in $count docsets matching '${*:-.*}'" >&2

--- a/bin/dasht
+++ b/bin/dasht
@@ -72,9 +72,27 @@
 # Written in 2016 by Suraj N. Kurapati <https://github.com/sunaku/dasht>
 # Distributed under the terms of the ISC license (refer to README file).
 
+: ${DASHT_USE_DASH_APP:=false}
+if $DASHT_USE_DASH_APP; then
+  : ${DASHT_DOCSETS_DIR:="/Users/smackesey/Library/Application Support/Dash"}
+else
+  : ${DASHT_DOCSETS_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}/dasht/docsets}
+fi
+
 if test $# -gt 0; then
   pattern=$1
   shift
+fi
+
+# Ensure any docsets we are accessing from the Dash.app library have had their
+# documents extracted. Dash.app leaves the documents in the tarball by default.
+if $DASHT_USE_DASH_APP; then
+  dasht-docsets "$@" | while read docset; do
+    root=("$DASHT_DOCSETS_DIR/"*/*"/${docset}.docset")
+    if ! test -d "${root}/Contents/Resources/Documents"; then
+      dasht-docsets-extract "$root/Contents/Resources/tarix.tgz"
+    fi
+  done
 fi
 
 count=$(dasht-docsets "$@" | wc -l)
@@ -85,6 +103,7 @@ if test $count -eq 0; then
 fi
 
 trap 'exit 44' USR1 # exit with a nonzero status when no results are found
+
 if ! dasht-query-html "$pattern" "$@"; then
   # notify user when no results are found so they can refine their search
   echo "dasht: '$pattern' not found in $count docsets matching '${*:-.*}'" >&2

--- a/bin/dasht-docsets
+++ b/bin/dasht-docsets
@@ -53,7 +53,7 @@
 
 : ${DASHT_USE_DASH_APP:=false}
 if $DASHT_USE_DASH_APP; then
-  : ${DASHT_DOCSETS_DIR:="/Users/smackesey/Library/Application Support/Dash"}
+  : ${DASHT_DOCSETS_DIR:="$HOME/Library/Application Support/Dash"}
 else
   : ${DASHT_DOCSETS_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}/dasht/docsets}
 fi

--- a/bin/dasht-docsets
+++ b/bin/dasht-docsets
@@ -34,6 +34,11 @@
 #   If undefined, its value is assumed to be `$XDG_DATA_HOME/dasht/docsets/`
 #   or, if `XDG_DATA_HOME` is undefined, `$HOME/.local/share/dasht/docsets/`.
 #
+# `DASHT_USE_DASH_APP`
+#   Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+#   docset management commands (install, remove, update). Also changes the
+#   default `DASHT_DOCSETS_DIR` to "~/Library/Application Support/Dash".
+#
 # ## SEE ALSO
 #
 # dasht-docsets-install(1), dasht-docsets-update(1), dasht-docsets-remove(1),
@@ -46,9 +51,22 @@
 # Written in 2016 by Suraj N. Kurapati <https://github.com/sunaku/dasht>
 # Distributed under the terms of the ISC license (refer to README file).
 
-: ${DASHT_DOCSETS_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}/dasht/docsets}
+: ${DASHT_USE_DASH_APP:=false}
+if $DASHT_USE_DASH_APP; then
+  : ${DASHT_DOCSETS_DIR:="/Users/smackesey/Library/Application Support/Dash"}
+else
+  : ${DASHT_DOCSETS_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}/dasht/docsets}
+fi
 
-ls "$DASHT_DOCSETS_DIR" |
+{
+  if $DASHT_USE_DASH_APP; then
+    for x in "$DASHT_DOCSETS_DIR"/*/*/*.docset; do
+      basename "$x"
+    done
+  else
+    ls "$DASHT_DOCSETS_DIR"
+  fi
+} | 
 sed -n 's/\.docset$//p' |
 sort -u |
 grep -E -i "$(IFS='|'; echo "$*")"

--- a/bin/dasht-docsets-extract
+++ b/bin/dasht-docsets-extract
@@ -60,39 +60,50 @@
 # Written in 2016 by Suraj N. Kurapati <https://github.com/sunaku/dasht>
 # Distributed under the terms of the ISC license (refer to README file).
 
-: ${DASHT_DOCSETS_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}/dasht/docsets}
 : ${DASHT_USE_DASH_APP:=false}
-
 if $DASHT_USE_DASH_APP; then
-  echo "extract, install, remove, and update operations are disabled when \
-    DASHT_USE_DASH_APP=true." >&2
-  exit 46
+  : ${DASHT_DOCSETS_DIR:="/Users/smackesey/Library/Application Support/Dash"}
+else
+  : ${DASHT_DOCSETS_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}/dasht/docsets}
 fi
 
 test $# -gt 0
 for tgz; do
-  want="$DASHT_DOCSETS_DIR/$(basename "$tgz" .tgz).docset"
-  have="$DASHT_DOCSETS_DIR/$(tar -t -f "$tgz" -z | head -1 | sed 's|/.*||')"
 
-  # for dasht-docsets-update(1), the extracted directory will already exist
-  # with the correct name, but we need to temporarily rename it back to the
-  # wrong name so that the archive extraction below can update its contents
-  # in place, rather than extracting out to a new (and different) directory
-  test "$have" = "$want" -o ! -e "$want" || mv "$want" "$have"
+  # Extract Documents dir inside existing Dash.app docset directory. Dash.app
+  # leaves the Documents inside the tarball tarix.tgz by default.
+  if $DASHT_USE_DASH_APP; then
+    pushd "$(dirname "$tgz")" >/dev/null
+    docset_name="$(basename "$(dirname "$(dirname "$(dirname "$tgz")")")")"
+    tar -x -f "$tgz" "$docset_name/Contents/Resources/Documents"
+    mv "$docset_name/Contents/Resources/Documents" .
+    rm -r "$docset_name"
+    popd >/dev/null
+  else
 
-  # extract the archive; the extracted directory's path is defined by $have
-  tar -v -C "$DASHT_DOCSETS_DIR" -x -f "$tgz" -z
+    want="$DASHT_DOCSETS_DIR/$(basename "$tgz" .tgz).docset"
+    have="$DASHT_DOCSETS_DIR/$(tar -t -f "$tgz" -z | head -1 | sed 's|/.*||')"
 
-  # rename the extracted directory to have the same rootname as the archive
-  test "$have" = "$want" || mv "$have" "$want"
+    # for dasht-docsets-update(1), the extracted directory will already exist
+    # with the correct name, but we need to temporarily rename it back to the
+    # wrong name so that the archive extraction below can update its contents
+    # in place, rather than extracting out to a new (and different) directory
+    test "$have" = "$want" -o ! -e "$want" || mv "$want" "$have"
 
-  # remove any stale files that were left behind by the previous extraction
-  { find "$want" -print
-    tar -t -f "$tgz" -z | sed -e "s|^[^/]*|$want|" -e 's|/$||'
-  } | sort -r | uniq -c | sed -n 's/^ *1 //p' | while read -r arg; do
-      if test -d "$arg"
-      then rmdir "$arg"
-      else rm -v "$arg"
-      fi
-  done
+    # extract the archive; the extracted directory's path is defined by $have
+    tar -v -C "$DASHT_DOCSETS_DIR" -x -f "$tgz" -z
+
+    # rename the extracted directory to have the same rootname as the archive
+    test "$have" = "$want" || mv "$have" "$want"
+
+    # remove any stale files that were left behind by the previous extraction
+    { find "$want" -print
+      tar -t -f "$tgz" -z | sed -e "s|^[^/]*|$want|" -e 's|/$||'
+    } | sort -r | uniq -c | sed -n 's/^ *1 //p' | while read -r arg; do
+        if test -d "$arg"
+        then rmdir "$arg"
+        else rm -v "$arg"
+        fi
+    done
+  fi
 done

--- a/bin/dasht-docsets-extract
+++ b/bin/dasht-docsets-extract
@@ -62,7 +62,7 @@
 
 : ${DASHT_USE_DASH_APP:=false}
 if $DASHT_USE_DASH_APP; then
-  : ${DASHT_DOCSETS_DIR:="/Users/smackesey/Library/Application Support/Dash"}
+  : ${DASHT_DOCSETS_DIR:="$HOME/Library/Application Support/Dash"}
 else
   : ${DASHT_DOCSETS_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}/dasht/docsets}
 fi
@@ -74,36 +74,36 @@ for tgz; do
   # leaves the Documents inside the tarball tarix.tgz by default.
   if $DASHT_USE_DASH_APP; then
     pushd "$(dirname "$tgz")" >/dev/null
-    docset_name="$(basename "$(dirname "$(dirname "$(dirname "$tgz")")")")"
+    docset_name="$(basename "${tgz%/*/*/*}")"
     tar -x -f "$tgz" "$docset_name/Contents/Resources/Documents"
     mv "$docset_name/Contents/Resources/Documents" .
     rm -r "$docset_name"
     popd >/dev/null
-  else
-
-    want="$DASHT_DOCSETS_DIR/$(basename "$tgz" .tgz).docset"
-    have="$DASHT_DOCSETS_DIR/$(tar -t -f "$tgz" -z | head -1 | sed 's|/.*||')"
-
-    # for dasht-docsets-update(1), the extracted directory will already exist
-    # with the correct name, but we need to temporarily rename it back to the
-    # wrong name so that the archive extraction below can update its contents
-    # in place, rather than extracting out to a new (and different) directory
-    test "$have" = "$want" -o ! -e "$want" || mv "$want" "$have"
-
-    # extract the archive; the extracted directory's path is defined by $have
-    tar -v -C "$DASHT_DOCSETS_DIR" -x -f "$tgz" -z
-
-    # rename the extracted directory to have the same rootname as the archive
-    test "$have" = "$want" || mv "$have" "$want"
-
-    # remove any stale files that were left behind by the previous extraction
-    { find "$want" -print
-      tar -t -f "$tgz" -z | sed -e "s|^[^/]*|$want|" -e 's|/$||'
-    } | sort -r | uniq -c | sed -n 's/^ *1 //p' | while read -r arg; do
-        if test -d "$arg"
-        then rmdir "$arg"
-        else rm -v "$arg"
-        fi
-    done
+    continue
   fi
+
+  want="$DASHT_DOCSETS_DIR/$(basename "$tgz" .tgz).docset"
+  have="$DASHT_DOCSETS_DIR/$(tar -t -f "$tgz" -z | head -1 | sed 's|/.*||')"
+
+  # for dasht-docsets-update(1), the extracted directory will already exist
+  # with the correct name, but we need to temporarily rename it back to the
+  # wrong name so that the archive extraction below can update its contents
+  # in place, rather than extracting out to a new (and different) directory
+  test "$have" = "$want" -o ! -e "$want" || mv "$want" "$have"
+
+  # extract the archive; the extracted directory's path is defined by $have
+  tar -v -C "$DASHT_DOCSETS_DIR" -x -f "$tgz" -z
+
+  # rename the extracted directory to have the same rootname as the archive
+  test "$have" = "$want" || mv "$have" "$want"
+
+  # remove any stale files that were left behind by the previous extraction
+  { find "$want" -print
+    tar -t -f "$tgz" -z | sed -e "s|^[^/]*|$want|" -e 's|/$||'
+  } | sort -r | uniq -c | sed -n 's/^ *1 //p' | while read -r arg; do
+      if test -d "$arg"
+      then rmdir "$arg"
+      else rm -v "$arg"
+      fi
+  done
 done

--- a/bin/dasht-docsets-extract
+++ b/bin/dasht-docsets-extract
@@ -39,6 +39,16 @@
 #   If undefined, its value is assumed to be `$XDG_DATA_HOME/dasht/docsets/`
 #   or, if `XDG_DATA_HOME` is undefined, `$HOME/.local/share/dasht/docsets/`.
 #
+# `DASHT_USE_DASH_APP`
+#   Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+#   docset management commands (install, remove, update). Also changes the
+#   default `DASHT_DOCSETS_DIR` to "~/Library/Application Support/Dash".
+#
+# ## EXIT STATUS
+#
+# 46
+#   Command was not executed because `DASHT_USE_DASH_APP` is set.
+#
 # ## SEE ALSO
 #
 # dasht-docsets-install(1), dasht-docsets-update(1), [Dash]
@@ -51,6 +61,13 @@
 # Distributed under the terms of the ISC license (refer to README file).
 
 : ${DASHT_DOCSETS_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}/dasht/docsets}
+: ${DASHT_USE_DASH_APP:=false}
+
+if $DASHT_USE_DASH_APP; then
+  echo "extract, install, remove, and update operations are disabled when \
+    DASHT_USE_DASH_APP=true." >&2
+  exit 46
+fi
 
 test $# -gt 0
 for tgz; do

--- a/bin/dasht-docsets-inherit
+++ b/bin/dasht-docsets-inherit
@@ -1,0 +1,72 @@
+#!/bin/sh -e
+#
+# # DASHT-DOCSETS-INHERIT 1       2020-05-16                            2.4.0
+#
+# ## NAME
+#
+# dasht-docsets-inherit - unpack docsets from Dash.app
+#
+# ## SYNOPSIS
+#
+# `dasht-docsets-inherit` [*NAME*...]
+#
+# ### Examples
+#
+# `dasht-docsets-inherit`
+#   Unpack all installed Dash.app docsets.
+#
+# `dasht-docsets-inherit` sh
+#   Unpack Dash.app docsets whose names contain "sh".
+#
+# `dasht-docsets` sh 'c$'
+#   Unpack Dash.app docsets whose names contain "sh" or end in "c".
+#
+# ## DESCRIPTION
+#
+# Unpack specified Dash.app docsets. This is necessary to use the Docsets with
+# `dasht`. Docsets are specified by passing one or more name filters as
+# arguments, which are matched against docset names. If no filters are
+# specified, all docsets are unpacked. Note that `DASHT_USE_DASH_APP` must be
+# set to `true` for this script to execute.
+#
+# ## ENVIRONMENT
+#
+# `DASHT_USE_DASH_APP`
+#   Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+#   docset management commands (install, remove, update). Also changes the
+#   default `DASHT_DOCSETS_DIR` to "~/Library/Application Support/Dash".
+#
+# ## EXIT STATUS
+#
+# 44
+#   No results were found.
+# 46
+#   Command was not executed because `DASHT_USE_DASH_APP` is not set.
+#  
+# ## SEE ALSO
+#
+# dasht-docsets(1), [Dash]
+#
+# [Dash]: https://kapeli.com/dash
+#
+# ## AUTHOR
+#
+# Written in 2016 by Suraj N. Kurapati <https://github.com/sunaku/dasht>
+# Distributed under the terms of the ISC license (refer to README file).
+
+: ${DASHT_USE_DASH_APP:=false}
+if $DASHT_USE_DASH_APP; then
+  : ${DASHT_DOCSETS_DIR:="$HOME/Library/Application Support/Dash"}
+else
+  exit 46
+fi
+
+# Ensure any docsets we are accessing from the Dash.app library have had their
+# documents extracted. Dash.app leaves the documents in the tarball by default.
+dasht-docsets "$@" | while read docset; do
+  for root in "$DASHT_DOCSETS_DIR"/*/*/"$docset".docset; do
+    if ! test -d "${root}/Contents/Resources/Documents"; then
+      dasht-docsets-extract "$root/Contents/Resources/tarix.tgz"
+    fi
+  done
+done

--- a/bin/dasht-docsets-install
+++ b/bin/dasht-docsets-install
@@ -44,6 +44,16 @@
 #   If undefined, its value is assumed to be `$XDG_CACHE_HOME/dasht/`
 #   or, if `XDG_CACHE_HOME` is also undefined, `$HOME/.cache/dasht/`.
 #
+# `DASHT_USE_DASH_APP`
+#   Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+#   docset management commands (install, remove, update). Also changes the
+#   default `DASHT_DOCSETS_DIR` to "~/Library/Application Support/Dash".
+#
+# ## EXIT STATUS
+#
+# 46
+#   Command was not executed because `DASHT_USE_DASH_APP` is set.
+#
 # ## SEE ALSO
 #
 # dasht-docsets-extract(1), dasht-docsets-update(1), dasht-docsets-remove(1),
@@ -58,6 +68,13 @@
 
 : ${DASHT_DOCSETS_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}/dasht/docsets}
 : ${DASHT_CACHE_DIR:=${XDG_CACHE_HOME:-$HOME/.cache}/dasht}
+: ${DASHT_USE_DASH_APP:=false}
+
+if $DASHT_USE_DASH_APP; then
+  echo "extract, install, remove, and update operations are disabled when \
+    DASHT_USE_DASH_APP=true." >&2
+  exit 46
+fi
 
 test "$1" = '-f' -o "$1" = '--force' && force=1 && shift || unset force
 

--- a/bin/dasht-docsets-remove
+++ b/bin/dasht-docsets-remove
@@ -39,6 +39,16 @@
 #   If undefined, its value is assumed to be `$XDG_DATA_HOME/dasht/docsets/`
 #   or, if `XDG_DATA_HOME` is undefined, `$HOME/.local/share/dasht/docsets/`.
 #
+# `DASHT_USE_DASH_APP`
+#   Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+#   docset management commands (install, remove, update). Also changes the
+#   default `DASHT_DOCSETS_DIR` to "~/Library/Application Support/Dash".
+#
+# ## EXIT STATUS
+#
+# 46
+#   Command was not executed because `DASHT_USE_DASH_APP` is set.
+#
 # ## SEE ALSO
 #
 # dasht-docsets-install(1), dasht-docsets-update(1), dasht-docsets(1), [Dash]
@@ -49,6 +59,15 @@
 #
 # Written in 2016 by Suraj N. Kurapati <https://github.com/sunaku/dasht>
 # Distributed under the terms of the ISC license (refer to README file).
+
+: ${DASHT_DOCSETS_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}/dasht/docsets}
+: ${DASHT_USE_DASH_APP:=false}
+
+if $DASHT_USE_DASH_APP; then
+  echo "extract, install, remove, and update operations are disabled when \
+    DASHT_USE_DASH_APP=true." >&2
+  exit 46
+fi
 
 : ${DASHT_DOCSETS_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}/dasht/docsets}
 

--- a/bin/dasht-docsets-update
+++ b/bin/dasht-docsets-update
@@ -33,6 +33,16 @@
 #   If undefined, its value is assumed to be `$XDG_DATA_HOME/dasht/docsets/`
 #   or, if `XDG_DATA_HOME` is undefined, `$HOME/.local/share/dasht/docsets/`.
 #
+# `DASHT_USE_DASH_APP`
+#   Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+#   docset management commands (install, remove, update). Also changes the
+#   default `DASHT_DOCSETS_DIR` to "~/Library/Application Support/Dash".
+#
+# ## EXIT STATUS
+#
+# 46
+#   Command was not executed because `DASHT_USE_DASH_APP` is set.
+#
 # ## SEE ALSO
 #
 # dasht-docsets-extract(1), dasht-docsets-install(1), dasht-docsets-remove(1),
@@ -46,6 +56,13 @@
 # Distributed under the terms of the ISC license (refer to README file).
 
 : ${DASHT_DOCSETS_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}/dasht/docsets}
+: ${DASHT_USE_DASH_APP:=false}
+
+if $DASHT_USE_DASH_APP; then
+  echo "extract, install, remove, and update operations are disabled when \
+    DASHT_USE_DASH_APP=true." >&2
+  exit 46
+fi
 
 dasht-docsets "$@" | while read -r docset; do
   ls "$DASHT_DOCSETS_DIR/$docset"*.tgz

--- a/bin/dasht-query-html
+++ b/bin/dasht-query-html
@@ -47,6 +47,11 @@
 #   If undefined, its value is assumed to be `$XDG_DATA_HOME/dasht/docsets/`
 #   or, if `XDG_DATA_HOME` is undefined, `$HOME/.local/share/dasht/docsets/`.
 #
+# `DASHT_USE_DASH_APP`
+#   Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+#   docset management commands (install, remove, update). Also changes the
+#   default `DASHT_DOCSETS_DIR` to "~/Library/Application Support/Dash".
+#
 # ## EXIT STATUS
 #
 # 44

--- a/bin/dasht-query-line
+++ b/bin/dasht-query-line
@@ -93,7 +93,7 @@
 
 : ${DASHT_USE_DASH_APP:=false}
 if $DASHT_USE_DASH_APP; then
-  : ${DASHT_DOCSETS_DIR:="/Users/smackesey/Library/Application Support/Dash"}
+  : ${DASHT_DOCSETS_DIR:="$HOME/Library/Application Support/Dash"}
 else
   : ${DASHT_DOCSETS_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}/dasht/docsets}
 fi

--- a/bin/dasht-query-line
+++ b/bin/dasht-query-line
@@ -70,6 +70,11 @@
 #   If undefined, its value is assumed to be `$XDG_DATA_HOME/dasht/docsets/`
 #   or, if `XDG_DATA_HOME` is undefined, `$HOME/.local/share/dasht/docsets/`.
 #
+# `DASHT_USE_DASH_APP`
+#   Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+#   docset management commands (install, remove, update). Also changes the
+#   default `DASHT_DOCSETS_DIR` to "~/Library/Application Support/Dash".
+#
 # ## EXIT STATUS
 #
 # 44
@@ -86,7 +91,12 @@
 # Written in 2016 by Suraj N. Kurapati <https://github.com/sunaku/dasht>
 # Distributed under the terms of the ISC license (refer to README file).
 
-: ${DASHT_DOCSETS_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}/dasht/docsets}
+: ${DASHT_USE_DASH_APP:=false}
+if $DASHT_USE_DASH_APP; then
+  : ${DASHT_DOCSETS_DIR:="/Users/smackesey/Library/Application Support/Dash"}
+else
+  : ${DASHT_DOCSETS_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}/dasht/docsets}
+fi
 
 pattern=$(echo " $1 " | sed -e 's/[%_]/\\&/g' -e 's/[[:space:]]\{1,\}/%/g')
 test $# -gt 0 && shift # shift off PATTERN so argv contains solely DOCSETs
@@ -95,7 +105,12 @@ status=44 # (default) exit with a nonzero status when no results are found
 trap 'status=0' USR1 # override default exit status when results are found
 
 dasht-docsets "$@" | while read -r docset; do
-  database="$DASHT_DOCSETS_DIR/$docset".docset/Contents/Resources/docSet.dsidx
+  if $DASHT_USE_DASH_APP; then
+    relpath=("$DASHT_DOCSETS_DIR"/*/*/"$docset".docset)
+    database="$relpath/Contents/Resources/docSet.dsidx"
+  else
+    database="$DASHT_DOCSETS_DIR/$docset".docset/Contents/Resources/docSet.dsidx
+  fi
   file_url="file://$(dirname "$database")/Documents/"
 
   dasht-query-exec "$pattern" "$database" -line |

--- a/bin/dasht-server
+++ b/bin/dasht-server
@@ -36,6 +36,11 @@
 #   If undefined, its value is assumed to be `$XDG_DATA_HOME/dasht/docsets/`
 #   or, if `XDG_DATA_HOME` is undefined, `$HOME/.local/share/dasht/docsets/`.
 #
+# `DASHT_USE_DASH_APP`
+#   Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+#   docset management commands (install, remove, update). Also changes the
+#   default `DASHT_DOCSETS_DIR` to "~/Library/Application Support/Dash".
+#
 # ## SEE ALSO
 #
 # socat(1), dasht-server-http(1), dasht-docsets(1), dasht(1), [Dash]

--- a/bin/dasht-server-http
+++ b/bin/dasht-server-http
@@ -37,6 +37,11 @@
 #   If undefined, its value is assumed to be `$XDG_DATA_HOME/dasht/docsets/`
 #   or, if `XDG_DATA_HOME` is undefined, `$HOME/.local/share/dasht/docsets/`.
 #
+# `DASHT_USE_DASH_APP`
+#   Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+#   docset management commands (install, remove, update). Also changes the
+#   default `DASHT_DOCSETS_DIR` to "~/Library/Application Support/Dash".
+#
 # ## SEE ALSO
 #
 # dasht-query-html(1), dasht-server(1), dasht-docsets(1), dasht(1), [Dash]

--- a/man/man1/dasht-docsets-extract.1
+++ b/man/man1/dasht-docsets-extract.1
@@ -31,6 +31,15 @@ If an extracted directory already exists, its contents are updated in place.
 Defines the filesystem location where your Dash \[la]https://kapeli.com/dash\[ra] docsets are installed.
 If undefined, its value is assumed to be \fB\fC$XDG_DATA_HOME/dasht/docsets/\fR
 or, if \fB\fCXDG_DATA_HOME\fR is undefined, \fB\fC$HOME/.local/share/dasht/docsets/\fR\&.
+.TP
+\fB\fCDASHT_USE_DASH_APP\fR
+Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+docset management commands (install, remove, update). Also changes the
+default \fB\fCDASHT_DOCSETS_DIR\fR to "~/Library/Application Support/Dash".
+.SH EXIT STATUS
+.TP
+46
+Command was not executed because \fB\fCDASHT_USE_DASH_APP\fR is set.
 .SH SEE ALSO
 .PP
 .BR dasht-docsets-install (1), 

--- a/man/man1/dasht-docsets-inherit.1
+++ b/man/man1/dasht-docsets-inherit.1
@@ -1,0 +1,44 @@
+.TH DASHT\-DOCSETS\-INHERIT 1       2020\-05\-16                            2.4.0
+.SH NAME
+.PP
+dasht\-docsets\-inherit \- unpack docsets from Dash.app
+.SH SYNOPSIS
+.PP
+\fB\fCdasht\-docsets\-inherit\fR [\fINAME\fP\&...]
+.SS Examples
+.TP
+\fB\fCdasht\-docsets\-inherit\fR
+Unpack all installed Dash.app docsets.
+.TP
+\fB\fCdasht\-docsets\-inherit\fR sh
+Unpack Dash.app docsets whose names contain "sh".
+.TP
+\fB\fCdasht\-docsets\fR sh 'c$'
+Unpack Dash.app docsets whose names contain "sh" or end in "c".
+.SH DESCRIPTION
+.PP
+Unpack specified Dash.app docsets. This is necessary to use the Docsets with
+\fB\fCdasht\fR\&. Docsets are specified by passing one or more name filters as
+arguments, which are matched against docset names. If no filters are
+specified, all docsets are unpacked. Note that \fB\fCDASHT_USE_DASH_APP\fR must be
+set to \fB\fCtrue\fR for this script to execute.
+.SH ENVIRONMENT
+.TP
+\fB\fCDASHT_USE_DASH_APP\fR
+Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+docset management commands (install, remove, update). Also changes the
+default \fB\fCDASHT_DOCSETS_DIR\fR to "~/Library/Application Support/Dash".
+.SH EXIT STATUS
+.PP
+44
+  No results were found.
+46
+  Command was not executed because \fB\fCDASHT_USE_DASH_APP\fR is not set.
+.SH SEE ALSO
+.PP
+.BR dasht-docsets (1), 
+Dash \[la]https://kapeli.com/dash\[ra]
+.SH AUTHOR
+.PP
+Written in 2016 by Suraj N. Kurapati \[la]https://github.com/sunaku/dasht\[ra]
+Distributed under the terms of the ISC license (refer to README file).

--- a/man/man1/dasht-docsets-install.1
+++ b/man/man1/dasht-docsets-install.1
@@ -37,6 +37,15 @@ or, if \fB\fCXDG_DATA_HOME\fR is undefined, \fB\fC$HOME/.local/share/dasht/docse
 Defines the filesystem location where download links are cached.
 If undefined, its value is assumed to be \fB\fC$XDG_CACHE_HOME/dasht/\fR
 or, if \fB\fCXDG_CACHE_HOME\fR is also undefined, \fB\fC$HOME/.cache/dasht/\fR\&.
+.TP
+\fB\fCDASHT_USE_DASH_APP\fR
+Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+docset management commands (install, remove, update). Also changes the
+default \fB\fCDASHT_DOCSETS_DIR\fR to "~/Library/Application Support/Dash".
+.SH EXIT STATUS
+.TP
+46
+Command was not executed because \fB\fCDASHT_USE_DASH_APP\fR is set.
 .SH SEE ALSO
 .PP
 .BR dasht-docsets-extract (1), 

--- a/man/man1/dasht-docsets-remove.1
+++ b/man/man1/dasht-docsets-remove.1
@@ -32,6 +32,15 @@ Forces the operation by overriding the interactive confirmation prompt.
 Defines the filesystem location where your Dash \[la]https://kapeli.com/dash\[ra] docsets are installed.
 If undefined, its value is assumed to be \fB\fC$XDG_DATA_HOME/dasht/docsets/\fR
 or, if \fB\fCXDG_DATA_HOME\fR is undefined, \fB\fC$HOME/.local/share/dasht/docsets/\fR\&.
+.TP
+\fB\fCDASHT_USE_DASH_APP\fR
+Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+docset management commands (install, remove, update). Also changes the
+default \fB\fCDASHT_DOCSETS_DIR\fR to "~/Library/Application Support/Dash".
+.SH EXIT STATUS
+.TP
+46
+Command was not executed because \fB\fCDASHT_USE_DASH_APP\fR is set.
 .SH SEE ALSO
 .PP
 .BR dasht-docsets-install (1), 

--- a/man/man1/dasht-docsets-update.1
+++ b/man/man1/dasht-docsets-update.1
@@ -27,6 +27,15 @@ patterns.  If no \fINAME\fPs are given, all available docsets are matched.
 Defines the filesystem location where your Dash \[la]https://kapeli.com/dash\[ra] docsets are installed.
 If undefined, its value is assumed to be \fB\fC$XDG_DATA_HOME/dasht/docsets/\fR
 or, if \fB\fCXDG_DATA_HOME\fR is undefined, \fB\fC$HOME/.local/share/dasht/docsets/\fR\&.
+.TP
+\fB\fCDASHT_USE_DASH_APP\fR
+Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+docset management commands (install, remove, update). Also changes the
+default \fB\fCDASHT_DOCSETS_DIR\fR to "~/Library/Application Support/Dash".
+.SH EXIT STATUS
+.TP
+46
+Command was not executed because \fB\fCDASHT_USE_DASH_APP\fR is set.
 .SH SEE ALSO
 .PP
 .BR dasht-docsets-extract (1), 

--- a/man/man1/dasht-docsets.1
+++ b/man/man1/dasht-docsets.1
@@ -28,6 +28,11 @@ patterns, if specified, before it is printed to stdout.
 Defines the filesystem location where your Dash \[la]https://kapeli.com/dash\[ra] docsets are installed.
 If undefined, its value is assumed to be \fB\fC$XDG_DATA_HOME/dasht/docsets/\fR
 or, if \fB\fCXDG_DATA_HOME\fR is undefined, \fB\fC$HOME/.local/share/dasht/docsets/\fR\&.
+.TP
+\fB\fCDASHT_USE_DASH_APP\fR
+Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+docset management commands (install, remove, update). Also changes the
+default \fB\fCDASHT_DOCSETS_DIR\fR to "~/Library/Application Support/Dash".
 .SH SEE ALSO
 .PP
 .BR dasht-docsets-install (1), 

--- a/man/man1/dasht-query-html.1
+++ b/man/man1/dasht-query-html.1
@@ -40,6 +40,11 @@ undefined, it becomes a whitespace wildcard and thereby matches everything.
 Defines the filesystem location where your Dash \[la]https://kapeli.com/dash\[ra] docsets are installed.
 If undefined, its value is assumed to be \fB\fC$XDG_DATA_HOME/dasht/docsets/\fR
 or, if \fB\fCXDG_DATA_HOME\fR is undefined, \fB\fC$HOME/.local/share/dasht/docsets/\fR\&.
+.TP
+\fB\fCDASHT_USE_DASH_APP\fR
+Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+docset management commands (install, remove, update). Also changes the
+default \fB\fCDASHT_DOCSETS_DIR\fR to "~/Library/Application Support/Dash".
 .SH EXIT STATUS
 .TP
 44

--- a/man/man1/dasht-query-line.1
+++ b/man/man1/dasht-query-line.1
@@ -66,6 +66,11 @@ url = file:///home/sunny/.local/share/dasht/docsets/Bash.docset/Contents/Resourc
 Defines the filesystem location where your Dash \[la]https://kapeli.com/dash\[ra] docsets are installed.
 If undefined, its value is assumed to be \fB\fC$XDG_DATA_HOME/dasht/docsets/\fR
 or, if \fB\fCXDG_DATA_HOME\fR is undefined, \fB\fC$HOME/.local/share/dasht/docsets/\fR\&.
+.TP
+\fB\fCDASHT_USE_DASH_APP\fR
+Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+docset management commands (install, remove, update). Also changes the
+default \fB\fCDASHT_DOCSETS_DIR\fR to "~/Library/Application Support/Dash".
 .SH EXIT STATUS
 .TP
 44

--- a/man/man1/dasht-server-http.1
+++ b/man/man1/dasht-server-http.1
@@ -32,6 +32,11 @@ as its \fIPATTERN\fP and \fIDOCSETS\fP arguments.
 Defines the filesystem location where your Dash \[la]https://kapeli.com/dash\[ra] docsets are installed.
 If undefined, its value is assumed to be \fB\fC$XDG_DATA_HOME/dasht/docsets/\fR
 or, if \fB\fCXDG_DATA_HOME\fR is undefined, \fB\fC$HOME/.local/share/dasht/docsets/\fR\&.
+.TP
+\fB\fCDASHT_USE_DASH_APP\fR
+Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+docset management commands (install, remove, update). Also changes the
+default \fB\fCDASHT_DOCSETS_DIR\fR to "~/Library/Application Support/Dash".
 .SH SEE ALSO
 .PP
 .BR dasht-query-html (1), 

--- a/man/man1/dasht-server.1
+++ b/man/man1/dasht-server.1
@@ -32,6 +32,11 @@ dasht\-server | xargs \-n1 w3m
 Defines the filesystem location where your Dash \[la]https://kapeli.com/dash\[ra] docsets are installed.
 If undefined, its value is assumed to be \fB\fC$XDG_DATA_HOME/dasht/docsets/\fR
 or, if \fB\fCXDG_DATA_HOME\fR is undefined, \fB\fC$HOME/.local/share/dasht/docsets/\fR\&.
+.TP
+\fB\fCDASHT_USE_DASH_APP\fR
+Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+docset management commands (install, remove, update). Also changes the
+default \fB\fCDASHT_DOCSETS_DIR\fR to "~/Library/Application Support/Dash".
 .SH SEE ALSO
 .PP
 .BR socat (1), 

--- a/man/man1/dasht.1
+++ b/man/man1/dasht.1
@@ -43,6 +43,11 @@ undefined, it becomes a whitespace wildcard and thereby matches everything.
 Defines the filesystem location where your Dash \[la]https://kapeli.com/dash\[ra] docsets are installed.
 If undefined, its value is assumed to be \fB\fC$XDG_DATA_HOME/dasht/docsets/\fR
 or, if \fB\fCXDG_DATA_HOME\fR is undefined, \fB\fC$HOME/.local/share/dasht/docsets/\fR\&.
+.TP
+\fB\fCDASHT_USE_DASH_APP\fR
+Set to "true" to use Dash.app's (MacOS only) docset library. Disables
+docset management commands (install, remove, update). Also changes the
+default \fB\fCDASHT_DOCSETS_DIR\fR to "~/Library/Application Support/Dash".
 .SH EXIT STATUS
 .TP
 44


### PR DESCRIPTION
Per my comment on #52:

My approach here was pretty simple, I added a new configuration variable `DASHT_USE_DASH_APP` that makes `dasht` use the `Dash.app` docsets. This also causes all of the docset management commands (install, update, remove, extract) to exit with a (new) exit code of 46. This seemed appropriate because if you are going to use the `Dash.app` library, it is best to just let `Dash.app` manage the docsets rather than trying to make sure `dasht` and `Dash.app` handle things exactly the same way.

One thing I wasn't sure of was whether to commit updated manpages. The `Development` section of the README says to rebuild the manpages, but the `man` directory is also in the gitignore. I can rebuild them and add them to this PR if you like.