### PR TITLE
Fix dasht-server-http serving "400 Bad Request" on requests for "/"

### DIFF
--- a/bin/dasht-server-http
+++ b/bin/dasht-server-http
@@ -75,7 +75,7 @@ url=$(awk '
 
 # serve translated local file:// URLs over HTTP
 # (skip the / homepage and /? form submissions)
-if ! echo "$url" | grep -q '^/$\|^/?'; then
+if ! test "$url" = / -o -z "${url##/\?*}"; then
   file=${url%#*} # strip URI fragment, if any
 
   if test -f "$file"; then


### PR DESCRIPTION
This was reported in sunaku/dasht#51. It's not clear to me if this only affects
macOS users.

The problem was the `grep` query changed here doesn't match queries for "/":

    ~ $ cat urls
    /
    /?
    /?query
    /foo
    /bar
    ~ $ cat urls | grep '^/$\|^/?'
    /?
    /?query

The two patterns to match for are fairly simple, so they can instead be tested
for with simple string equality checks.