### PR TITLE
store downloaded archives in DASHT_CACHE_DIR instead of using DASHT_DOCSETS_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,11 @@ which defines the filesystem location where your [Dash] docsets are installed.
 If undefined, its value is assumed to be `$XDG_DATA_HOME/dasht/docsets/` or,
 if `XDG_DATA_HOME` is also undefined, `$HOME/.local/share/dasht/docsets/`.
 
-You may optionally configure the `DASHT_CACHE_DIR` environment variable,
-which defines the filesystem location where download links are cached.
-If undefined, its value is assumed to be `$XDG_CACHE_HOME/dasht/`
-or, if `XDG_CACHE_HOME` is also undefined, `$HOME/.cache/dasht/`.
+You may optionally configure the `DASHT_CACHE_DIR` environment variable, which
+defines the filesystem location where download links and downloaded docset
+archives are cached. If undefined, its value is assumed to be
+`$XDG_CACHE_HOME/dasht/` or, if `XDG_CACHE_HOME` is also undefined,
+`$HOME/.cache/dasht/`.
 
 ## Development
 

--- a/bin/dasht-docsets-install
+++ b/bin/dasht-docsets-install
@@ -40,9 +40,10 @@
 #   or, if `XDG_DATA_HOME` is undefined, `$HOME/.local/share/dasht/docsets/`.
 #
 # `DASHT_CACHE_DIR`
-#   Defines the filesystem location where download links are cached.
-#   If undefined, its value is assumed to be `$XDG_CACHE_HOME/dasht/`
-#   or, if `XDG_CACHE_HOME` is also undefined, `$HOME/.cache/dasht/`.
+#   Defines the filesystem location where download links and downloaded
+#   archives are cached. If undefined, its value is assumed to be
+#   `$XDG_CACHE_HOME/dasht/` or, if `XDG_CACHE_HOME` is also undefined,
+#   `$HOME/.cache/dasht/`.
 #
 # ## SEE ALSO
 #
@@ -89,9 +90,9 @@ for docset; do
   echo "Install $docset docset [y/N]" | xargs -p | grep -q . || continue
 
   basename="$docset".tgz
-  tgz="$DASHT_DOCSETS_DIR/$basename"
+  tgz="$DASHT_CACHE_DIR/$basename"
   url="https://kapeli.com/feeds/$basename"
 
-  wget -P "$DASHT_DOCSETS_DIR" -N -c "$url"
+  wget -P "$DASHT_CACHE_DIR" -N -c "$url"
   gzip -t "$tgz" && dasht-docsets-extract "$tgz"
 done

--- a/bin/dasht-docsets-remove
+++ b/bin/dasht-docsets-remove
@@ -39,6 +39,12 @@
 #   If undefined, its value is assumed to be `$XDG_DATA_HOME/dasht/docsets/`
 #   or, if `XDG_DATA_HOME` is undefined, `$HOME/.local/share/dasht/docsets/`.
 #
+# `DASHT_CACHE_DIR`
+#   Defines the filesystem location where download links and downloaded
+#   archives are cached. If undefined, its value is assumed to be
+#   `$XDG_CACHE_HOME/dasht/` or, if `XDG_CACHE_HOME` is also undefined,
+#   `$HOME/.cache/dasht/`.
+#
 # ## SEE ALSO
 #
 # dasht-docsets-install(1), dasht-docsets-update(1), dasht-docsets(1), [Dash]
@@ -51,6 +57,7 @@
 # Distributed under the terms of the ISC license (refer to README file).
 
 : ${DASHT_DOCSETS_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}/dasht/docsets}
+: ${DASHT_CACHE_DIR:=${XDG_CACHE_HOME:-$HOME/.cache}/dasht}
 
 test "$1" = '-f' -o "$1" = '--force' && force=1 && shift || unset force
 
@@ -62,7 +69,6 @@ for docset; do
   test -n "$force" || # don't ask for confirmation when it's being forced
   echo "Remove $docset docset [y/N]" | xargs -p | grep -q . || continue
 
-  rootname="$DASHT_DOCSETS_DIR/$docset"
-  rm -v -f -r "$rootname".docset \
-              "$rootname".tgz
+  rm -v -f -r "$DASHT_DOCSETS_DIR/$docset".docset \
+              "$DASHT_CACHE_DIR/$docset".tgz
 done

--- a/bin/dasht-docsets-update
+++ b/bin/dasht-docsets-update
@@ -33,6 +33,12 @@
 #   If undefined, its value is assumed to be `$XDG_DATA_HOME/dasht/docsets/`
 #   or, if `XDG_DATA_HOME` is undefined, `$HOME/.local/share/dasht/docsets/`.
 #
+# `DASHT_CACHE_DIR`
+#   Defines the filesystem location where download links and downloaded
+#   archives are cached. If undefined, its value is assumed to be
+#   `$XDG_CACHE_HOME/dasht/` or, if `XDG_CACHE_HOME` is also undefined,
+#   `$HOME/.cache/dasht/`.
+#
 # ## SEE ALSO
 #
 # dasht-docsets-extract(1), dasht-docsets-install(1), dasht-docsets-remove(1),
@@ -46,15 +52,16 @@
 # Distributed under the terms of the ISC license (refer to README file).
 
 : ${DASHT_DOCSETS_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}/dasht/docsets}
+: ${DASHT_CACHE_DIR:=${XDG_CACHE_HOME:-$HOME/.cache}/dasht}
 
 dasht-docsets "$@" | while read -r docset; do
-  ls "$DASHT_DOCSETS_DIR/$docset"*.tgz
+  ls "$DASHT_CACHE_DIR/$docset"*.tgz
 done | sort -u | while read -r tgz; do
   last_modified_at="$tgz".last_modified_at
   url="https://kapeli.com/feeds/$(basename "$tgz")"
 
   touch -r "$tgz" "$last_modified_at"
-  wget -P "$DASHT_DOCSETS_DIR" -N "$url"
+  wget -P "$DASHT_CACHE_DIR" -N "$url"
   test "$tgz" -nt "$last_modified_at" && dasht-docsets-extract "$tgz"
   rm "$last_modified_at"
 done

--- a/man/man1/dasht-docsets-install.1
+++ b/man/man1/dasht-docsets-install.1
@@ -34,7 +34,7 @@ If undefined, its value is assumed to be \fB\fC$XDG_DATA_HOME/dasht/docsets/\fR
 or, if \fB\fCXDG_DATA_HOME\fR is undefined, \fB\fC$HOME/.local/share/dasht/docsets/\fR\&.
 .TP
 \fB\fCDASHT_CACHE_DIR\fR
-Defines the filesystem location where download links are cached.
+Defines the filesystem location where download links and downloaded archives are cached.
 If undefined, its value is assumed to be \fB\fC$XDG_CACHE_HOME/dasht/\fR
 or, if \fB\fCXDG_CACHE_HOME\fR is also undefined, \fB\fC$HOME/.cache/dasht/\fR\&.
 .SH SEE ALSO

--- a/man/man1/dasht-docsets-remove.1
+++ b/man/man1/dasht-docsets-remove.1
@@ -32,6 +32,11 @@ Forces the operation by overriding the interactive confirmation prompt.
 Defines the filesystem location where your Dash \[la]https://kapeli.com/dash\[ra] docsets are installed.
 If undefined, its value is assumed to be \fB\fC$XDG_DATA_HOME/dasht/docsets/\fR
 or, if \fB\fCXDG_DATA_HOME\fR is undefined, \fB\fC$HOME/.local/share/dasht/docsets/\fR\&.
+.TP
+\fB\fCDASHT_CACHE_DIR\fR
+Defines the filesystem location where download links and downloaded archives are cached.
+If undefined, its value is assumed to be \fB\fC$XDG_CACHE_HOME/dasht/\fR
+or, if \fB\fCXDG_CACHE_HOME\fR is also undefined, \fB\fC$HOME/.cache/dasht/\fR\&.
 .SH SEE ALSO
 .PP
 .BR dasht-docsets-install (1), 

--- a/man/man1/dasht-docsets-update.1
+++ b/man/man1/dasht-docsets-update.1
@@ -27,6 +27,11 @@ patterns.  If no \fINAME\fPs are given, all available docsets are matched.
 Defines the filesystem location where your Dash \[la]https://kapeli.com/dash\[ra] docsets are installed.
 If undefined, its value is assumed to be \fB\fC$XDG_DATA_HOME/dasht/docsets/\fR
 or, if \fB\fCXDG_DATA_HOME\fR is undefined, \fB\fC$HOME/.local/share/dasht/docsets/\fR\&.
+.TP
+\fB\fCDASHT_CACHE_DIR\fR
+Defines the filesystem location where download links and downloaded archives are cached.
+If undefined, its value is assumed to be \fB\fC$XDG_CACHE_HOME/dasht/\fR
+or, if \fB\fCXDG_CACHE_HOME\fR is also undefined, \fB\fC$HOME/.cache/dasht/\fR\&.
 .SH SEE ALSO
 .PP
 .BR dasht-docsets-extract (1), 


### PR DESCRIPTION
This improves interoperability with dash-docs.el (see https://github.com/dash-docs-el/dash-docs) which otherwise tries to open all archives stored in the DOCSETS directory when creating a list of installed docsets (which is a time consuming process and results in a timeout in dash-docs).

Since this is mostly a workaround for an issue with dash-docs.el, feel free to just close the PR without merging it. But if you're interested in a merge, I could try to provide some sort of (automatic?) migration script for existing installations.